### PR TITLE
Pak Emulator Fixes

### DIFF
--- a/Emulator/PAK.Stream.Emulator/Pak/PakBuilderFactory.cs
+++ b/Emulator/PAK.Stream.Emulator/Pak/PakBuilderFactory.cs
@@ -69,9 +69,13 @@ public class PakBuilderFactory
     /// <returns>True if the route contains the group, false otherwise</returns>
     private bool RoutePartialMatches(Route route, RouteGroupTuple group)
     {
-        var match = Regex.Match(group.Route.FullPath, @".+\.[^\\]+");
-        if (!match.Success) return false;
-        return match.Value.Contains(route.FullPath);
+        string groupPath = group.Route.FullPath;
+        int dotIndex = groupPath.LastIndexOf('.');
+        if (dotIndex == -1) return false; // Doesn't have any archive files, don't bother with this
+        int fileEnd = groupPath.IndexOf('\\', dotIndex);
+        if (fileEnd == -1) fileEnd = groupPath.Length; // There are no children of the archive file
+        var res = groupPath.Substring(0,fileEnd).Contains(route.FullPath);
+        return res;
     }
 }
 

--- a/Emulator/PAK.Stream.Emulator/Pak/PakBuilderFactory.cs
+++ b/Emulator/PAK.Stream.Emulator/Pak/PakBuilderFactory.cs
@@ -71,7 +71,7 @@ public class PakBuilderFactory
     {
         var match = Regex.Match(group.Route.FullPath, @".+\.[^\\]+");
         if (!match.Success) return false;
-        return route.FullPath.Contains(match.Value);
+        return match.Value.Contains(route.FullPath);
     }
 }
 

--- a/Emulator/PAK.Stream.Emulator/Pak/PakBuilderFactory.cs
+++ b/Emulator/PAK.Stream.Emulator/Pak/PakBuilderFactory.cs
@@ -1,5 +1,6 @@
 ﻿using FileEmulationFramework.Lib;
 using FileEmulationFramework.Lib.IO;
+using System.Text.RegularExpressions;
 
 namespace PAK.Stream.Emulator.Pak;
 
@@ -44,9 +45,9 @@ public class PakBuilderFactory
         var route = new Route(path);
         foreach (var group in RouteGroupTuples)
         {
-            if (!route.Matches(group.Route.FullPath))
+            if (!route.Matches(group.Route.FullPath) && !RoutePartialMatches(route, group))
                 continue;
-            
+
             // Make builder if not made.
             builder ??= new PakBuilder();
 
@@ -57,6 +58,20 @@ public class PakBuilderFactory
         }
 
         return builder != null;
+    }
+
+    /// <summary>
+    /// Check if a route is in a group. Unlike Route.Matches this considers the path to the actual archive file
+    /// E.g. the route init_free.bin\field\script will match init_free.bin as this recognises the actual file is at init_free.bin
+    /// </summary>
+    /// <param name="route">The route to compare</param>
+    /// <param name="group">The group to compare</param>
+    /// <returns>True if the route contains the group, false otherwise</returns>
+    private bool RoutePartialMatches(Route route, RouteGroupTuple group)
+    {
+        var match = Regex.Match(group.Route.FullPath, @".+\.[^\\]+");
+        if (!match.Success) return false;
+        return route.FullPath.Contains(match.Value);
     }
 }
 

--- a/FileEmulationFramework.Lib/IO/FileSlice.cs
+++ b/FileEmulationFramework.Lib/IO/FileSlice.cs
@@ -1,4 +1,5 @@
 ﻿using FileEmulationFramework.Lib.Utilities;
+using System.Collections.Concurrent;
 
 namespace FileEmulationFramework.Lib.IO;
 
@@ -12,7 +13,7 @@ public class FileSlice
     /// Caches existing open handles to the file.
     /// Used for fast subsequent access of files; we keep the handles open.
     /// </summary>
-    private static readonly Dictionary<string, IntPtr> HandleCache = new(StringComparer.OrdinalIgnoreCase);
+    private static readonly ConcurrentDictionary<string, IntPtr> HandleCache = new(StringComparer.OrdinalIgnoreCase);
 
     /// <summary>
     /// Offset of the data to get from the file.


### PR DESCRIPTION
Some minor fixes for PAK Emulator needed for PAK Merging to work properly in Persona Essentials. (see [#12](https://github.com/Sewer56/p5rpc.modloader/pull/12) over there)
- Fixes a problem where nested files would not be detected
- Converts uses of Dictionary to ConcurrentDictionary to prevent errors when merging many files asynchronously