### PR TITLE
Allow adding to paks using API

### DIFF
--- a/Emulator/Interfaces/PAK.Stream.Emulator.Interfaces/IPakEmulator.cs
+++ b/Emulator/Interfaces/PAK.Stream.Emulator.Interfaces/IPakEmulator.cs
@@ -43,4 +43,10 @@ public interface IPakEmulator
     /// <param name="route">The route the file is in</param>
     /// <param name="inPakPath">The path in the pak the file will take</param>
     public void AddFile(string file, string route, string inPakPath);
+
+    /// <summary>
+    /// Adds a directory to PAK Emulator so it's like the files were in FEmulator\PAK
+    /// </summary>
+    /// <param name="dir">The directory to add the files from</param>
+    public void AddDirectory(string dir);
 }

--- a/Emulator/Interfaces/PAK.Stream.Emulator.Interfaces/IPakEmulator.cs
+++ b/Emulator/Interfaces/PAK.Stream.Emulator.Interfaces/IPakEmulator.cs
@@ -36,4 +36,11 @@ public interface IPakEmulator
     /// <returns>The data of the desired entry or null if it could not be found in the pak</returns>
     public ReadOnlyMemory<byte>? GetEntry(Strim pak, string entryPath);
 
+    /// <summary>
+    /// Adds a new file to be injected into emulated paks
+    /// </summary>
+    /// <param name="file">The path to the file to add</param>
+    /// <param name="route">The route the file is in</param>
+    /// <param name="inPakPath">The path in the pak the file will take</param>
+    public void AddFile(string file, string route, string inPakPath);
 }

--- a/Emulator/PAK.Stream.Emulator/Pak/PakBuilder.cs
+++ b/Emulator/PAK.Stream.Emulator/Pak/PakBuilder.cs
@@ -32,6 +32,18 @@ public class PakBuilder
 
     /// <summary>
     /// Builds a PAK file.
+    /// Adds a file to the Virtual PAK builder using its path in the pak.
+    /// </summary>
+    /// <param name="filePath">Full path to the file.</param>
+    /// <param name="inPakPath">Path to where the file will be in the pak</param>
+    public void AddOrReplaceFileWithPath(string filePath, string inPakPath)
+    {
+        _customFiles[inPakPath.Replace('\\', '/')] = new(filePath);
+    }
+
+
+    /// <summary>
+    /// Builds an PAK file.
     /// </summary>
     public unsafe MultiStream Build(IntPtr handle, string filepath, Logger? logger = null, string folder = "", long baseOffset = 0)
     {

--- a/Emulator/PAK.Stream.Emulator/Pak/PakBuilderFactory.cs
+++ b/Emulator/PAK.Stream.Emulator/Pak/PakBuilderFactory.cs
@@ -1,11 +1,20 @@
 ﻿using FileEmulationFramework.Lib;
 using FileEmulationFramework.Lib.IO;
+using FileEmulationFramework.Lib.Utilities;
+using System.Collections.Concurrent;
 
 namespace PAK.Stream.Emulator.Pak;
 
 public class PakBuilderFactory
 {
     internal List<RouteGroupTuple> RouteGroupTuples = new();
+    internal ConcurrentBag<RouteFileTuple> RouteFileTuples = new();
+    private Logger _log;
+
+    public PakBuilderFactory(Logger log)
+    {
+        _log = log;
+    }
 
     /// <summary>
     /// Adds all available routes from folders.
@@ -32,6 +41,12 @@ public class PakBuilderFactory
         }
     }
 
+    public void AddFile(string file, string route, string inPakPath)
+    {
+        _log.Info($"[PakBuilderFactory] Added file {file} with route {route} in pak path {inPakPath}");
+        RouteFileTuples.Add(new RouteFileTuple { FilePath = file, Route = new Route(route), VirtualPath = inPakPath });
+    }
+
     /// <summary>
     /// Tries to create a PAK from a given route.
     /// </summary>
@@ -44,7 +59,7 @@ public class PakBuilderFactory
         var route = new Route(path);
         foreach (var group in RouteGroupTuples)
         {
-            if (!route.Matches(group.Route.FullPath) && !RoutePartialMatches(route, group))
+            if (!route.Matches(group.Route.FullPath) && !RoutePartialMatches(route, group.Route.FullPath))
                 continue;
 
             // Make builder if not made.
@@ -56,6 +71,18 @@ public class PakBuilderFactory
                 builder.AddOrReplaceFile(Path.Combine(dir, file), Path.GetFileName(path));
         }
 
+        foreach(var group in RouteFileTuples)
+        {
+            if (!route.Matches(group.Route.FullPath) && !RoutePartialMatches(route, group.Route.FullPath))
+                continue;
+
+            // Make builder if not made.
+            builder ??= new PakBuilder();
+
+            builder.AddOrReplaceFileWithPath(group.FilePath, group.VirtualPath);
+            
+        }
+
         return builder != null;
     }
 
@@ -64,19 +91,18 @@ public class PakBuilderFactory
     /// E.g. the route init_free.bin\field\script will match init_free.bin as this recognises the actual file is at init_free.bin
     /// </summary>
     /// <param name="route">The route to compare</param>
-    /// <param name="group">The group to compare</param>
+    /// <param name="group">The full path of the group to compare</param>
     /// <returns>True if the route contains the group, false otherwise</returns>
-    private bool RoutePartialMatches(Route route, RouteGroupTuple group)
+    private bool RoutePartialMatches(Route route, string groupPath)
     {
-        string groupPath = group.Route.FullPath;
         int dotIndex = groupPath.LastIndexOf('.');
-        if (dotIndex == -1) 
+        if (dotIndex == -1)
             return false; // Doesn't have any archive files, don't bother with this
-        
+
         int fileEnd = groupPath.IndexOf('\\', dotIndex);
-        if (fileEnd == -1) 
+        if (fileEnd == -1)
             fileEnd = groupPath.Length; // There are no children of the archive file
-        
+
         return groupPath.AsSpan(0, fileEnd).Contains(route.FullPath.AsSpan(), StringComparison.OrdinalIgnoreCase);
     }
 }
@@ -92,4 +118,22 @@ internal struct RouteGroupTuple
     /// Files bound by this route.
     /// </summary>
     public DirectoryFilesGroup Files;
+}
+
+internal struct RouteFileTuple
+{
+    /// <summary>
+    /// Route associated with this tuple.
+    /// </summary>
+    public Route Route;
+
+    /// <summary>
+    /// Path to the file bound by this route.
+    /// </summary>
+    public string FilePath;
+
+    /// <summary>
+    /// The path the bound file will take in its pak.
+    /// </summary>
+    public string VirtualPath;
 }

--- a/Emulator/PAK.Stream.Emulator/PakEmulator.cs
+++ b/Emulator/PAK.Stream.Emulator/PakEmulator.cs
@@ -124,4 +124,6 @@ public class PakEmulator : IEmulator
     public void AddFile(string file, string route, string inPakPath) => _builderFactory.AddFile(file, route, inPakPath);
 
     internal List<RouteGroupTuple> GetInput() => _builderFactory.RouteGroupTuples;
+
+    internal void AddFromFolders(string dir) => _builderFactory.AddFromFolders(dir);
 }

--- a/Emulator/PAK.Stream.Emulator/PakEmulator.cs
+++ b/Emulator/PAK.Stream.Emulator/PakEmulator.cs
@@ -20,7 +20,7 @@ public class PakEmulator : IEmulator
     public bool DumpFiles { get; set; }
 
     // Note: Handle->Stream exists because hashing IntPtr is easier; thus can resolve reads faster.
-    private readonly PakBuilderFactory _builderFactory = new();
+    private readonly PakBuilderFactory _builderFactory;
     private readonly ConcurrentDictionary<string, MultiStream?> _pathToStream = new(StringComparer.OrdinalIgnoreCase);
     private Logger _log;
 
@@ -28,6 +28,7 @@ public class PakEmulator : IEmulator
     {
         _log = log;
         DumpFiles = dumpFiles;
+        _builderFactory = new(log);
     }
 
     public bool TryCreateFile(IntPtr handle, string filepath, string route, out IEmulatedFile emulated)
@@ -119,6 +120,8 @@ public class PakEmulator : IEmulator
         stream.CopyTo(fileStream);
         _log.Info($"[PakEmulator] Written To {filePath}");
     }
+
+    public void AddFile(string file, string route, string inPakPath) => _builderFactory.AddFile(file, route, inPakPath);
 
     internal List<RouteGroupTuple> GetInput() => _builderFactory.RouteGroupTuples;
 }

--- a/Emulator/PAK.Stream.Emulator/PakEmulatorApi.cs
+++ b/Emulator/PAK.Stream.Emulator/PakEmulatorApi.cs
@@ -92,6 +92,11 @@ public class PakEmulatorApi : IPakEmulator
         _pakEmulator.AddFile(file, route, inPakPath);
     }
 
+    public void AddDirectory(string dir)
+    {
+        _pakEmulator.AddFromFolders(dir);
+    }
+
     public ReadOnlyMemory<byte>? GetEntry(Strim pak, string entryPath)
     {
         entryPath = entryPath.Replace('\\', '/');

--- a/Emulator/PAK.Stream.Emulator/PakEmulatorApi.cs
+++ b/Emulator/PAK.Stream.Emulator/PakEmulatorApi.cs
@@ -87,6 +87,11 @@ public class PakEmulatorApi : IPakEmulator
         return result;
     }
 
+    public void AddFile(string file, string route, string inPakPath)
+    {
+        _pakEmulator.AddFile(file, route, inPakPath);
+    }
+
     public ReadOnlyMemory<byte>? GetEntry(Strim pak, string entryPath)
     {
         entryPath = entryPath.Replace('\\', '/');


### PR DESCRIPTION
Adds two functions to the pak emulator api: `AddFile` and `AddDirectory` to allow other mods to programmatically add files to paks.

This is needed for a [Persona Essentials update](https://github.com/Sewer56/p5rpc.modloader/pull/17) however, it's also just nice for other mods to have the option.