### PR TITLE
BF Emulator Fixes

### DIFF
--- a/Emulator/BF.File.Emulator/BfEmulator.cs
+++ b/Emulator/BF.File.Emulator/BfEmulator.cs
@@ -58,7 +58,7 @@ public class BfEmulator : IEmulator
             case Game.P5R:
                 _flowFormat = FlowFormatVersion.Version3BigEndian;
                 _library = LibraryLookup.GetLibrary("P5R");
-                _encoding = AtlusEncoding.GetByName("P5");
+                _encoding = AtlusEncoding.GetByName("P5R");
                 break;
         }
     }

--- a/Emulator/Interfaces/BF.File.Emulator.Interfaces/BF.File.Emulator.Interfaces.csproj
+++ b/Emulator/Interfaces/BF.File.Emulator.Interfaces/BF.File.Emulator.Interfaces.csproj
@@ -6,8 +6,4 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\..\..\FileEmulationFramework.Lib\FileEmulationFramework.Lib.csproj" />
-  </ItemGroup>
-
 </Project>

--- a/Emulator/Interfaces/BF.File.Emulator.Interfaces/Structures/IO/Structures.cs
+++ b/Emulator/Interfaces/BF.File.Emulator.Interfaces/Structures/IO/Structures.cs
@@ -1,6 +1,4 @@
-﻿using FileEmulationFramework.Lib.IO;
-
-namespace BF.File.Emulator.Interfaces.Structures.IO;
+﻿namespace BF.File.Emulator.Interfaces.Structures.IO;
 
 
 /// <summary>


### PR DESCRIPTION
- Fixes errors compiling P5R bf files due to the P5 Encoding being used
- Removed a project reference in the BF Emulator Interface that shouldn't have been there