### PR TITLE
Fix file write time not being emulated after all handles were close, update script tools to fix bugs in bf emulator 

### DIFF
--- a/FileEmulationFramework.Lib/Utilities/Native.cs
+++ b/FileEmulationFramework.Lib/Utilities/Native.cs
@@ -12,6 +12,11 @@ namespace FileEmulationFramework.Lib.Utilities;
 public static class Native
 {
     /// <summary>
+    /// The value of a handle that is invalid
+    /// </summary>
+    public static IntPtr INVALID_HANDLE_VALUE = new IntPtr(-1);
+    
+    /// <summary>
     /// <para>
     /// Loads the specified module into the address space of the calling process. The specified module may cause other modules to be loaded.
     /// </para>

--- a/FileEmulationFramework/FileAccessServer.cs
+++ b/FileEmulationFramework/FileAccessServer.cs
@@ -343,8 +343,10 @@ public static unsafe class FileAccessServer
 
                 lock (ThreadLock)
                 {
-                    HandleToInfoMap[hndl] = new(newFilePath, 0, emulatedFile);
+                    fileInfo = new(newFilePath, 0, emulatedFile);
+                    HandleToInfoMap[hndl] = fileInfo;
                     PathToHandleMap[newFilePath] = hndl;
+                    PathToVirtualFileMap[newFilePath] = fileInfo;
                 }
                 return ntStatus;
             }


### PR DESCRIPTION
This pr just has two small fixes from my last one (#24):
- My fix for #15 didn't properly work. If all handles to the emulated file were closed its size and last write time would no longer be emulated ever. I've fixed that
- Updated script tools to the [latest](https://github.com/tge-was-taken/Atlus-Script-Tools/commit/0a74cf05de30118ba60e9b1ff7b6cd61677085ed) to fix a bug that caused a BF's last write time to be emulated incorrectly [#103](https://github.com/tge-was-taken/Atlus-Script-Tools/pull/103) and one that caused non english character to break in bf messages [#102](https://github.com/tge-was-taken/Atlus-Script-Tools/pull/102)

That should be all from me on here for a while, I don't think there are any more bugs :D
I'll have a Persona Essentials pr for you tomorrow as well then we should be good to release all these updates finally :)