### PR TITLE
(BF Emulator) Fix crash when adding function alias to a function with no existing aliases

### DIFF
--- a/Emulator/BF.File.Emulator/Bf/BfBuilder.cs
+++ b/Emulator/BF.File.Emulator/Bf/BfBuilder.cs
@@ -229,6 +229,7 @@ public class BfBuilder
                 var existingFunc = library.FlowScriptModules[module].Functions[index];
                 if (FlowFunctionsSame(existingFunc, func))
                 {
+                    existingFunc.Aliases ??= new List<string>();
                     existingFunc.Aliases.Add(func.Name);
                 }
                 else


### PR DESCRIPTION
Does what it says on the tin. 
In my previous BF Emulator update (#24) I made it so library overrides that change a function's name add that name as an alias instead of completely overriding the original to improve compatibility. I missed the fact that a function isn't guaranteed to already have any aliases, so if it doesn't you get a null pointer exception trying to add the new alias :(