### PR TITLE
(BF, BMD, SPD, PAK) Fix files not being emulated after initial creation

### DIFF
--- a/Emulator/BF.File.Emulator/BfEmulator.cs
+++ b/Emulator/BF.File.Emulator/BfEmulator.cs
@@ -116,7 +116,7 @@ public class BfEmulator : IEmulator
             return false;
 
         stream = emulatedBf.Stream;
-        _pathToEmulated.TryAdd(outputPath, emulatedBf);
+        _pathToEmulated[outputPath] = emulatedBf;
         emulated = new EmulatedFile<Stream>(stream, emulatedBf.LastWriteTime);
         _log.Info("[BfEmulator] Created Emulated file with Path {0} and Last Write {1}", outputPath, emulatedBf.LastWriteTime);
 
@@ -150,7 +150,7 @@ public class BfEmulator : IEmulator
 
     public void RegisterFile(string destinationPath, Stream stream, DateTime lastWriteTime)
     {
-        _pathToEmulated.TryAdd(destinationPath, new EmulatedBf(stream, new List<string>(), lastWriteTime));
+        _pathToEmulated[destinationPath] = new EmulatedBf(stream, new List<string>(), lastWriteTime);
     }
 
     private void DumpFile(string route, Stream stream)

--- a/Emulator/BMD.File.Emulator/BmdEmulator.cs
+++ b/Emulator/BMD.File.Emulator/BmdEmulator.cs
@@ -115,7 +115,7 @@ public class BmdEmulator : IEmulator
             return false;
 
         stream = emulatedBmd.Stream;
-        _pathToEmulated.TryAdd(outputPath, emulatedBmd);
+        _pathToEmulated[outputPath] = emulatedBmd;
         emulated = new EmulatedFile<Stream>(stream, emulatedBmd.LastWriteTime);
         _log.Info("[BmdEmulator] Created Emulated file with Path {0} and Last Write {1}", outputPath, emulatedBmd.LastWriteTime);
 
@@ -149,7 +149,7 @@ public class BmdEmulator : IEmulator
 
     public void RegisterFile(string destinationPath, Stream stream, DateTime lastWriteTime)
     {
-        _pathToEmulated.TryAdd(destinationPath, new EmulatedBmd(stream, new List<string>(), lastWriteTime));
+        _pathToEmulated[destinationPath] = new EmulatedBmd(stream, new List<string>(), lastWriteTime);
     }
 
     private void DumpFile(string route, Stream stream)

--- a/Emulator/PAK.Stream.Emulator/PakEmulator.cs
+++ b/Emulator/PAK.Stream.Emulator/PakEmulator.cs
@@ -83,7 +83,7 @@ public class PakEmulator : IEmulator
 
         stream = builder!.Build(handle, srcDataPath);
 
-        _pathToStream.TryAdd(outputPath, stream);
+        _pathToStream[outputPath] = stream;
         emulated = new EmulatedFile<MultiStream>(stream);
         _log.Info("[PakEmulator] Created Emulated file with Path {0}", outputPath);
 

--- a/Emulator/SPD.File.Emulator/SpdEmulator.cs
+++ b/Emulator/SPD.File.Emulator/SpdEmulator.cs
@@ -79,7 +79,7 @@ public class SpdEmulator : IEmulator
         _pathToStream[outputPath] = null; // Avoid recursion into same file.
 
         stream = builder!.Build(srcDataPath, _log);
-        _pathToStream.TryAdd(outputPath, stream);
+        _pathToStream[outputPath] = stream;
         emulated = new EmulatedFile<MultiStream>(stream);
         _log.Info("[SpdEmulator] Created Emulated file with Path {0}", outputPath);
 
@@ -123,7 +123,7 @@ public class SpdEmulator : IEmulator
 
     public void RegisterFile(string destinationPath, Stream stream)
     {
-        _pathToStream.TryAdd(destinationPath, stream);
+        _pathToStream[destinationPath] = stream;
     }
 
     internal List<RouteGroupTuple> GetInput() => _builderFactory.RouteGroupTuples;


### PR DESCRIPTION
This fixes a bug that's present in BF, BMD, SPD, and PAK emulators that causes files to not be emulated if they are opened more than once (only the first creation works).

This is due to us using `TryAdd` in the `_pathToEmulated` concurrent dictionaries that should be used to pass back the previously emulated file when a file tries to be created subsequent times. It fails if something is already in the dictionary and since we put the value `null` in to prevent recursion, we end up with `null` even after emulation succeeds.

For simplicity I've just replaced `TryAdd` with a direct index (`dict[thing]`) instead of `TryUpdate` since I don't think concurrency is really a problem right now. Maybe this is something we need to consider more at some point but I'd guess that's a bigger problem?