### PR TITLE
(SPD): Fix potential crash when registering spds through the api

### DIFF
--- a/Emulator/SPD.File.Emulator/SpdEmulator.cs
+++ b/Emulator/SPD.File.Emulator/SpdEmulator.cs
@@ -1,4 +1,5 @@
-﻿using FileEmulationFramework.Interfaces;
+﻿using System.Collections.Concurrent;
+using FileEmulationFramework.Interfaces;
 using FileEmulationFramework.Interfaces.Reference;
 using FileEmulationFramework.Lib.IO;
 using FileEmulationFramework.Lib.Utilities;
@@ -19,7 +20,7 @@ public class SpdEmulator : IEmulator
 
     // Note: Handle->Stream exists because hashing IntPtr is easier; thus can resolve reads faster.
     private readonly SpriteBuilderFactory _builderFactory;
-    private readonly Dictionary<string, Stream?> _pathToStream = new(StringComparer.OrdinalIgnoreCase);
+    private readonly ConcurrentDictionary<string, Stream?> _pathToStream = new(StringComparer.OrdinalIgnoreCase);
     private readonly Logger _log;
 
     public SpdEmulator(Logger log, bool dumpFiles)


### PR DESCRIPTION
A small fix to change the `_pathToStream` Dictionary to a ConcurrenctDictionary to prevent an exception being thrown when registering a file through the API whilst something else is using the dictionary already.
This now matches with PAK, BMD, and BF emulators which also use a ConcurrentDictionary for this.

I'd guess that this was never encountered before because TryAdd was being used (which I changed in #29), so possibly the registered files weren't actually being registered. Hopefully it is the only problem, everything else seems good so far.