### PR TITLE
Update AST submodule (again) and add procedure overwriting

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/Heroes-Hacking-Central/Heroes.SDK.git
 [submodule "Submodules/Atlus-Script-Tools"]
 	path = Submodules/Atlus-Script-Tools
-	url = https://github.com/tge-was-taken/Atlus-Script-Tools.git
+	url = https://github.com/Persona-Modding/Atlus-Script-Tools.git

--- a/Emulator/BF.File.Emulator/Bf/BfBuilder.cs
+++ b/Emulator/BF.File.Emulator/Bf/BfBuilder.cs
@@ -149,6 +149,7 @@ public class BfBuilder
         compiler.Library = OverrideLibraries(library);
         compiler.Encoding = encoding;
         compiler.ProcedureHookMode = ProcedureHookMode.ImportedOnly;
+        compiler.OverwriteExistingProcedures = true;
         compiler.OverwriteExistingMsgs = true;
         if (listener != null)
             compiler.AddListener(listener);


### PR DESCRIPTION
This PR bandaids a mod conflict issue where BF compilation will fail if multiple mods edit the same flowscript procedure, causing infinite loads. Ideally the affected mods should also provide a proper compatibility patch but the patches too would rely on this change